### PR TITLE
Allow to summarize float numbers

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -12,7 +12,11 @@ class summaryCommand(sublime_plugin.TextCommand):
             if region_text:
                 print(region_text)
                 for number in region_text.split():
-                    summa += int(number)
+                    summa += float(number)
 
             self.view.replace(edit, region, '')
+
+        if summa.is_integer():
+            summa = int(summa)
+
         self.view.replace(edit, last, str(summa))


### PR DESCRIPTION
This PR adds an ability to summarize float numbers in addition to integer ones.

`summa.is_integer()` checks if a float can be treated as a whole integer e.g. `1.000`, thus avoiding to keep the part after the decimal point in the final result.